### PR TITLE
Add Trailing Slash to Directories

### DIFF
--- a/src/libs/io.ts
+++ b/src/libs/io.ts
@@ -17,7 +17,7 @@ export function getDirectories(srcPath: string, excludes: string | string[]): Si
     ignore: excludes,
     nodir: false
   }).map(path => ({
-    path: path.substring(0, path.length - 1),
+    path: path.substring(0, path.length - 1) + '/',
     isDirectory: true
   }));
 


### PR DESCRIPTION
Since directories and files can have the same base name (card.ts and card/) a trailing slash needs to be appended.